### PR TITLE
ReplimatUtility.GenerateIngredients: use non-throwing search on list...

### DIFF
--- a/Source/ReplimatUtility.cs
+++ b/Source/ReplimatUtility.cs
@@ -138,7 +138,7 @@ namespace Replimat
                     return directMatch || indirectMatch;
                 };
 
-                RecipeDef mealRecipe = DefDatabase<RecipeDef>.AllDefsListForReading.First(validator);
+                RecipeDef mealRecipe = DefDatabase<RecipeDef>.AllDefsListForReading.FirstOrDefault(validator);
 
                 if (mealRecipe != null)
                 {


### PR DESCRIPTION
…as intended, use the non-throwing version of searching the list, so that the case where a recipe match can't be found it is silently ignored.This is, as far as I can tell, the intended implementation.  The code certainly acts as though it should get `null` back, not a throw. :)