### PR TITLE
Patch for Ambition of the cosmic

### DIFF
--- a/Common/Patches/Patches_AoTC.xml
+++ b/Common/Patches/Patches_AoTC.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Ambition of the Cosmic</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<li Class="PatchOperationAdd">
+					<xpath>
+						Defs/ThingDef[defName="ReplimatComputer"]/comps/li[@Class="Replimat.CompProperties_ReplimatRestrictions"]/disallowedMeals</xpath>
+					<value>
+						<li>SNS_Meal_Nutrient_GenI</li>
+						<li>SNS_Meal_Nutrient_GenII</li>
+						<li>SNS_Meal_Nutrient_GenIII</li>
+						<li>SNS_Meal_Normal_GenII</li>
+						<li>SNS_Meal_Normal_GenIII</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>
+						Defs/ThingDef[defName="ReplimatComputer"]/comps/li[@Class="Replimat.CompProperties_ReplimatRestrictions"]/batchReplicableSurvivalMeals</xpath>
+					<value>
+						<li>SNS_Meal_Nutrient_GenI</li>
+						<li>SNS_Meal_Nutrient_GenII</li>
+						<li>SNS_Meal_Nutrient_GenIII</li>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
Hi

I've made this patch for myself because the meals from AoTC are too powerful to be used so freely within Replimat context :) You can now also create the nutrient bars from AoTC, however i've found they're "cheaper" than the worse packaged survival meals.